### PR TITLE
Remove local .note CSS styling

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -114,9 +114,6 @@ pre.prototype	{ background-color:#f7f8ff;
                   margin: 1em 4em 1em 0em ; }
 .return, .type	{ color: #177 }
 
-/* == Notes ==  */
-.note		{ margin-left: 2.5em; margin-right: 4ex ; font-size: 85% ; font-style: italic ; }
-
 /* Definitions */
 .defn		{ margin-left:0 ; margin-right: 2ex; 
                   margin-top: 0.1ex ; margin-bottom: 0.1ex ;


### PR DESCRIPTION
See w3c/sparql-query#168


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 26, 2024, 4:51 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Timed out after waiting 30000ms
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/sparql-federated-query%2322.)._
</details>
